### PR TITLE
Fix dialog border radius

### DIFF
--- a/themes/noctis.yaml
+++ b/themes/noctis.yaml
@@ -58,6 +58,9 @@ noctis:
   ha-card-border-radius: "5px"
   border-color: 'none'
 
+  # Dialog
+  ha-dialog-border-radius: "5px"
+
   # Icons
   paper-item-icon-color: '#EBEBEB'
   paper-item-icon-active-color: 'var(--accent-color)'


### PR DESCRIPTION
It seems Home Assistant is now using this variable to set dialogs border radius and defaults to 28px when undefined.